### PR TITLE
fix(renewer) Don't update concurrencyToken on renew. Do update lastRenew on renew

### DIFF
--- a/manager.go
+++ b/manager.go
@@ -165,6 +165,7 @@ func (l *LeaseManager) RenewLease(lease *Lease) (err error) {
 	clease.Counter++
 	if err = l.condUpdate(clease, *lease); err == nil {
 		lease.Counter = clease.Counter
+		lease.lastRenewal = time.Now()
 	}
 	return
 }

--- a/renewer.go
+++ b/renewer.go
@@ -56,10 +56,12 @@ func (l *leaseHolder) Renew() error {
 	// that we still hold.
 	for _, lease := range leases {
 		if lease.Owner == l.WorkerId {
-			// if we took this lease and it's not holds by this renewer
-			l.Lock()
-			l.heldLeases[lease.Key] = lease
-			l.Unlock()
+			// if we took this lease and it's not hold by this renewer
+			if _, ok := l.heldLeases[lease.Key]; !ok {
+				l.Lock()
+				l.heldLeases[lease.Key] = lease
+				l.Unlock()
+			}
 			if err := l.manager.RenewLease(lease); err != nil {
 				l.Logger.Debugf("Worker %s could not renew lease with key %s", l.WorkerId, lease.Key)
 			}


### PR DESCRIPTION
## Fix: Renewer concurrencyToken was being updated on renewal and it should not be
 * Don't update `lease.concurrencyToken` on renew if it was already held by the lease. 
 * Do update `lease.lastRenew` on renew along with the `lease.Counter`

This change is required as described in [issue #3](https://github.com/a8m/lease/issues/3).